### PR TITLE
Events page

### DIFF
--- a/_posts/2018-11-11-events.md
+++ b/_posts/2018-11-11-events.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Events"
+date: 2018-11-11 00:00:00
+categories: main
+---
+Check out the [Upcoming Events](/events/) page for tutorials, 
+workshops, BoFs, etc

--- a/events.md
+++ b/events.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Events
+permalink: /events/
+---
+
+# Upcoming Events
+
+## Supercomputing 2018 - Dallas, Tx
+[Managing HPC Software Complexity with Spack](https://sc18.supercomputing.org/presentation/?id=tut165&sess=sess252) 
+Presenters: Gregory B. Becker, Massimiliano Culpo, Matthew P. LeGendre,
+            Mario Melara, Peter Scheibel, Adam J. Stewart, Todd Gamblin.
+
+Time: Monday, November 12th, 8:30am - 5pm
+
+[Spack Community Birds of a Feather](https://sc18.supercomputing.org/presentation/?id=bof173&sess=sess42://sc18.supercomputing.org/presentation/?id=bof173&sess=sess428ession)
+Session Leader: Todd Gamblin 
+
+Time: Tuesday, November 13th, 12:15pm - 1:15pm
+
+[Spack Roundtable](https://scdoe.info/other-booth-activities/)
+Time: Wednesday November 14th, 3pm


### PR DESCRIPTION
Includes home page link to an events page. Currently the page holds information on SC18 events with their appropriate links.