### PR TITLE
Update events.md with SC19 info

### DIFF
--- a/_posts/2016-01-05-easy.md
+++ b/_posts/2016-01-05-easy.md
@@ -18,8 +18,8 @@ class Kripke(Package):
     """Kripke is a simple, scalable, 3D Sn deterministic particle
        transport proxy/mini app.
     """
-    homepage = "https://codesign.llnl.gov/kripke.php"
-    url      = "https://codesign.llnl.gov/downloads/kripke-openmp-1.1.tar.gz"
+    homepage = "https://computing.llnl.gov/projects/co-design/kripke"
+    url      = "https://computing.llnl.gov/downloads/kripke-openmp-1.1.tar.gz"
 
     version('1.1', '7fe6f2b26ed983a6ce5495ab701f85bf')
 

--- a/events.md
+++ b/events.md
@@ -6,17 +6,17 @@ permalink: /events/
 
 # Upcoming Events
 
-## Supercomputing 2018 - Dallas, Tx
-[Managing HPC Software Complexity with Spack](https://sc18.supercomputing.org/presentation/?id=tut165&sess=sess252) 
-Presenters: Gregory B. Becker, Massimiliano Culpo, Matthew P. LeGendre,
-            Mario Melara, Peter Scheibel, Adam J. Stewart, Todd Gamblin.
+## Supercomputing 2019 - Denver, Colorado
+[Managing HPC Software Complexity with Spack](https://sc19.supercomputing.org/?post_type=page&p=3479&id=tut164&sess=sess194) 
+Presenters: Todd Gamblin, Gregory Becker, Massimiliano Culpo, 
+            Mario Melara, Peter Scheibel, Adam J. Stewart.
 
-Time: Monday, November 12th, 8:30am - 5pm
+Time: Monday, November 18th, 8:30am - 5:00pm
 
-[Spack Community Birds of a Feather](https://sc18.supercomputing.org/presentation/?id=bof173&sess=sess42://sc18.supercomputing.org/presentation/?id=bof173&sess=sess428ession)
-Session Leader: Todd Gamblin 
+[Spack Community Birds of a Feather](https://sc19.supercomputing.org/?post_type=page&p=3479&id=bof189&sess=sess310)
+Session Leader: Adam J. Stewart
 
-Time: Tuesday, November 13th, 12:15pm - 1:15pm
+Time: Thursday, November 21st, 12:15pm - 1:15pm
 
-[Spack Roundtable](https://scdoe.info/other-booth-activities/)
-Time: Wednesday November 14th, 3pm
+[Spack Roundtable](https://scdoe.info/other-booth-activities/) in the Department of Energy booth 925
+Time: TBD


### PR DESCRIPTION
The DOE booth web page doesn't have anything listed yet for SC19, so I just put TBD. But the tutorial and BoF info is accurate.